### PR TITLE
Fix: Auto-create config file when not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Fixed
+- Auto-create config file when not exists to prevent errors on first run
+- Fixed error when running `list_all_docs` or `list_enabled_docs` before any configuration
+
 ## [1.0.0] - 2025-03-25
 ### Added
 - Initial release of docs-mcp MCP Server


### PR DESCRIPTION
## Overview
This PR fixes an issue where the MCP server would fail with an error when trying to execute commands such as `list_all_docs` or `list_enabled_docs` before any configuration file has been created.

## Changes
- Added a new `ensureConfigFile()` function that creates an empty config file if it doesn't exist
- Modified `loadDocConfig()` to call this function before trying to load the config
- Also updated `updateCrawledDoc()` to ensure config file exists
- Added explicit calls to `ensureConfigFile()` in tool handlers that read from the config file
- Updated CHANGELOG.md to document this bugfix

## Why
Previously, when running the MCP server for the first time, any attempt to list documents or get information about enabled documents would fail with a file not found error. This creates a poor first-run experience, as users need to manually create a config file or run other commands first.

With this change, the config file is automatically created when needed, making the server much more user-friendly.