### PR TITLE
Fix: Ensure config file creation, correct crawl paths, and improve WSL compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Auto-create config file when not exists to prevent errors on first run
 - Fixed error when running `list_all_docs` or `list_enabled_docs` before any configuration
+- Fixed incorrect path handling in document crawling that ignored the `--docsDir` parameter
+- Added WSL compatibility options to Puppeteer for better performance in WSL environments
 
 ## [1.0.0] - 2025-03-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Fixed
+- Auto-create config file when not exists to prevent errors on first run
+- Fixed error when running `list_all_docs` or `list_enabled_docs` before any configuration
+
 ## [1.0.0] - 2025-03-25
 ### Added
 - Initial release of docs-mcp MCP Server

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,7 @@ async function crawlAndSaveDocs(force: boolean = false): Promise<void> {
       const browser = await puppeteer.launch({
         // WSL-friendly options to avoid GPU issues
         args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'],
-        headless: 'new'
+        headless: true
       });
       
       try {


### PR DESCRIPTION
This PR introduces several improvements and fixes to enhance the stability and usability of the `open-docs-mcp` server, particularly regarding initial setup, file path handling during crawls, and compatibility with WSL environments.

**Key Changes:**

*   **Automatic Config File Creation:**
    *   Added an `ensureConfigFile()` function that automatically creates the `docs-config.json` file with default content (`{"enabledDocs":{},"crawledDocs":{}}`) in the specified `docsDir` if it doesn't exist.
    *   Relevant functions now call `ensureConfigFile()` before accessing the configuration, preventing errors on the first run or after clearing the cache directory.

*   **Crawl Path Correction:**
    *   Corrected the logic for constructing the save path for crawled documents within the `crawl_docs` function (e.g., using `const docDirPath = path.join(docDir, doc.name);`).
    *   Updated associated variable names and fixed parenthesis structure for accurate file path generation.

*   **WSL Compatibility Enhancement:**
    *   Added appropriate arguments to the Puppeteer launch options to improve compatibility and ensure proper operation when running the server within a Windows Subsystem for Linux (WSL) environment.

*   **Changelog:**
    *   Updated `CHANGELOG.md` to reflect these fixes and improvements.